### PR TITLE
Avoid stack overflow on creating pathArray

### DIFF
--- a/lib/thesis_inserter.rb
+++ b/lib/thesis_inserter.rb
@@ -1,4 +1,4 @@
-# 以下データ挿入
+# 論文データの挿入
 # ThesisInserter.new.upsertAll!
 
 require 'find'
@@ -10,77 +10,70 @@ class ThesisInserter
   TYPE = 'thesis'
 
   def upsertAll!
-    pathArray = fetchPathArray /.*\.pdf/
-
-    pathArray.each do |path|
-      texPath = path.match(/(.*)\.pdf/)[1] + ".tex"
-      if File.exist?(texPath) &&  !(Thesis.exists? url: path)
-        # メタデータの取得
-        authorData = "unknown"
-        titleData = "notitle"
-        dateData = "unknown"
-        yearData = "unknown"
-        File.open(texPath) do |file|
-          file.each_line do |line|
-            match = line.match(/author\{(.*?)\}/)
-            if authorData == "unknown" && match
-              authorData = match[1]
-            end
-
-            match = line.match(/title\{(.*?)\}/)
-            if match
-              titleData = match[1]
-            end
-
-            match = line.match(/date\{(.*?)\}/)
-            if match
-              dateData = match[1]
-            end
-
-            match = line.match(/year\{(.*?)\}/)
-            if match
-              yearData = match[1]
-            end
-          end
+    Find.find(THESIS_ROOT_DIRECTORY) do |path|
+      if path =~ /.*\.pdf/
+        texPath = path.match(/(.*)\.pdf/)[1] + ".tex"
+        if File.exist?(texPath) && !(Thesis.exists? url: path)
+          upsert path, texPath
         end
-
-        text = extractText(path)
- 
-        # Active Recordでデータ挿入
-        author = Author.find_by name: authorData
-        if !author
-          author = Author.create name: authorData
-        end
-        if yearData != "unknown"
-          thesis = Thesis.create title: titleData, year: yearData, url: path, author_id: author.id
-        else
-          thesis = Thesis.create title: titleData, year: dateData, url: path, author_id: author.id
-        end
-        
-        # Elasticsearchにデータ挿入
-        CLIENT.index index: INDEX, type: TYPE, id: thesis.id, body: { 
-          text: text
-        }
       end
     end
   end
 
   private
-  
-  def fetchPathArray(pattern = "")
-    pathArray = []
-    Find.find(THESIS_ROOT_DIRECTORY) do |f|
-      pathArray.push(f) if f =~ pattern
+
+    def upsert(path, texPath)
+      # メタデータの取得
+      authorData = "unknown"
+      titleData  = "notitle"
+      dateData   = "unknown"
+      yearData   = "unknown"
+      File.open(texPath) do |file|
+        file.each_line do |line|
+          match = line.match(/author\{(.*?)\}/)
+          authorData = match[1] if authorData == "unknown" && match
+
+          match = line.match(/title\{(.*?)\}/)
+          titleData  = match[1] if match
+            
+          match = line.match(/date\{(.*?)\}/)
+          dateData   = match[1] if match
+
+          match = line.match(/year\{(.*?)\}/)
+          yearData   = match[1] if match
+        end
+      end
+      
+      thesis = createThesis titleData, authorData, yearData, dateData, path
+      
+      text = extractText path
+      insertIntoElasticsearch thesis.id, text
     end
 
-    return pathArray
-  end
+    def createThesis(titleData, authorData, yearData, dateData, path)
+      author = Author.find_by name: authorData
+      if !author
+        author = Author.create name: authorData
+      end
 
-  # pathにはURLも可
-  def extractText(path)
-    data = Yomu.new path
+      if yearData != "unknown"
+        thesis = Thesis.create title: titleData, year: yearData, url: path, author_id: author.id
+      else
+        thesis = Thesis.create title: titleData, year: dateData, url: path, author_id: author.id
+      end
+    end
 
-    rawText = data.text
-    rawText.gsub(/\r\n|\n|\r/, "")
-  end
+    # pathにはURLも可
+    def extractText(path)
+      data = Yomu.new path
+
+      rawText = data.text
+      rawText.gsub(/\r\n|\n|\r/, "")
+    end
+
+    def insertIntoElasticsearch(thesisId, text)
+      CLIENT.index index: INDEX, type: TYPE, id: thesisId, body: { 
+        text: text
+      }
+    end
 end


### PR DESCRIPTION
論文の path 検索時に pathArray を作成しない実装にしてスタックオーバーフローを予防
ついでにメソッド分割( diff を読みにくくする嫌がらせ...)