### PR TITLE
Add how to use the mecab on ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,16 @@ brew install mecab
 brew install mecab-ipadic
 ```
 
+# mecab install (Ubuntu)
+```
+sudo apt-get install mecab mecab-ipadic-utf8
+```
+~/.bashrcに以下を追加
+```
+export MECAB_PATH="/usr/lib/libmecab.so.2"
+```
 
 # Rspec test 
-プルリクを出す前に実行して, example 全部通っているか確認
 ```bash
 bundle exec rails spec 
 


### PR DESCRIPTION
1. READMEにmecabの使用方法(Ubuntu)を追記
2. テストについて嘘が書いてあるのを削除