### PR TITLE
update search result and add access remitation rearound mailaddress

### DIFF
--- a/app/controllers/mail_addresses_controller.rb
+++ b/app/controllers/mail_addresses_controller.rb
@@ -1,5 +1,6 @@
 class MailAddressesController < ApplicationController
   skip_before_action :require_login, only: [:index, :new, :create]
+  before_action :exists_mail?, only: [:index]
   SUBJECT  = "【論文検索システム Escapism】 ユーザ登録ページのご案内"
 
   def index
@@ -23,5 +24,9 @@ class MailAddressesController < ApplicationController
 
     def send_email(address)
       Admin::InviteUserMailer.invite(address, SUBJECT).deliver
+    end
+
+    def exists_mail?
+      raise ActionController::RoutingError.new('here is only admin user page') unless Rails.application.routes.recognize_path(request.referrer)[:action] == "new"
     end
 end

--- a/app/controllers/theses_controller.rb
+++ b/app/controllers/theses_controller.rb
@@ -7,6 +7,7 @@ class ThesesController < ApplicationController
   before_action :init_set_popular_theses
 
   def index
+    @author = Author.all
     if params[:q]
       response = search_by_keyword(params[:q])
       thesisArray = []
@@ -23,7 +24,7 @@ class ThesesController < ApplicationController
           thesisArray.push(thesis)
         end
       end
-      @thesisArray = Kaminari.paginate_array(thesisArray).page(params[:page]).per(4)
+     @thesisArray = Kaminari.paginate_array(thesisArray).page(params[:page]).per(4)
     end
 
     @labos = Labo.all

--- a/app/views/theses/index.html.erb
+++ b/app/views/theses/index.html.erb
@@ -33,6 +33,7 @@
         <div class="col-sm-offset-1 col-xs-offset-1">
           <div class="page-header width">
             <h4><%= link_to(t[:thesis].title, thesis_path(t[:thesis])) %></h4>
+            <h4><%= t[:thesis].year %><%= @author.find(t[:thesis].id).name %></h4>
           </div>
           <p class="text-muted search_summary">
             <small><%= t[:body] %></small>


### PR DESCRIPTION
- メールアドレス入力後の success ページへの遷移以外をアクセスを制限
- 論文の検索結果に著者情報と執筆年度を追加