### PR TITLE
Feature/empty comment validation

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,9 +1,16 @@
 class CommentsController < ApplicationController
+  EMPTY = 0
+
   def create
     @thesis = Thesis.find(params[:thesis_id])
     if @thesis.nil?
       logger.error("Internal server error: CommentsController create action 3 lines: @theses is undefined")
       render_500
+    end
+
+    if empty_comment?(comment_params[:body])
+      redirect_to thesis_path(@thesis)
+      return
     end
     @comment = @thesis.comments.create(body: comment_params[:body], user_id: session[:user_id])
     redirect_to thesis_path(@thesis)
@@ -12,5 +19,9 @@ class CommentsController < ApplicationController
   private
     def comment_params
       params.require(:comment).permit(:body)
+    end
+
+    def empty_comment?(comment)
+      comment.length == EMPTY
     end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,12 +8,12 @@ class CommentsController < ApplicationController
       render_500
     end
 
-    if multiple_lines?(trim_multiple_newlines(comment_params[:body]))
+    if invalid?(comment_params[:body])
       redirect_to thesis_path(@thesis)
       return
     end
 
-    @comment = @thesis.comments.create(body: trim_multiple_newlines(comment_params[:body]), user_id: session[:user_id])
+    @comment = @thesis.comments.create(body: comment_params[:body], user_id: session[:user_id])
     redirect_to thesis_path(@thesis)
   end
   
@@ -22,12 +22,8 @@ class CommentsController < ApplicationController
       params.require(:comment).permit(:body)
     end
 
-    def trim_multiple_newlines(comment)
-      comment.gsub(/\R{2,}/,"\n")
-    end
-
-    def multiple_lines?(comment)
-      if comment.scan(/\R/).size >= MAX_LINES
+    def invalid?(comment)
+      if comment.scan(/\R/).size > MAX_LINES || comment.strip.blank?
         return true
       end
       return false

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,4 @@
 class CommentsController < ApplicationController
-  EMPTY = 0
 
   def create
     @thesis = Thesis.find(params[:thesis_id])
@@ -8,12 +7,7 @@ class CommentsController < ApplicationController
       render_500
     end
 
-    if empty?(comment_params[:body]) || only_newline?(comment_params[:body])
-      redirect_to thesis_path(@thesis)
-      return
-    end
-
-    @comment = @thesis.comments.create(body: comment_params[:body], user_id: session[:user_id])
+    @comment = @thesis.comments.create(body: trim_multiple_newlines(comment_params[:body]), user_id: session[:user_id])
     redirect_to thesis_path(@thesis)
   end
   
@@ -22,11 +16,7 @@ class CommentsController < ApplicationController
       params.require(:comment).permit(:body)
     end
 
-    def empty?(comment)
-      comment.length == EMPTY
-    end
-
-    def only_newline?(comment)
-      empty?(comment.gsub(/\R/, ""))
+    def trim_multiple_newlines(comment)
+      comment.gsub(/\R{2,}/,"\n")
     end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,6 @@
 class CommentsController < ApplicationController
   MAX_LINES = 10
 
-
   def create
     @thesis = Thesis.find(params[:thesis_id])
     if @thesis.nil?

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,10 +1,17 @@
 class CommentsController < ApplicationController
+  MAX_LINES = 10
+
 
   def create
     @thesis = Thesis.find(params[:thesis_id])
     if @thesis.nil?
       logger.error("Internal server error: CommentsController create action 3 lines: @theses is undefined")
       render_500
+    end
+
+    if multiple_lines?(trim_multiple_newlines(comment_params[:body]))
+      redirect_to thesis_path(@thesis)
+      return
     end
 
     @comment = @thesis.comments.create(body: trim_multiple_newlines(comment_params[:body]), user_id: session[:user_id])
@@ -18,5 +25,12 @@ class CommentsController < ApplicationController
 
     def trim_multiple_newlines(comment)
       comment.gsub(/\R{2,}/,"\n")
+    end
+
+    def multiple_lines?(comment)
+      if comment.scan(/\R/).size >= MAX_LINES
+        return true
+      end
+      return false
     end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,10 +8,11 @@ class CommentsController < ApplicationController
       render_500
     end
 
-    if empty_comment?(comment_params[:body])
+    if empty?(comment_params[:body]) || only_newline?(comment_params[:body])
       redirect_to thesis_path(@thesis)
       return
     end
+
     @comment = @thesis.comments.create(body: comment_params[:body], user_id: session[:user_id])
     redirect_to thesis_path(@thesis)
   end
@@ -21,7 +22,11 @@ class CommentsController < ApplicationController
       params.require(:comment).permit(:body)
     end
 
-    def empty_comment?(comment)
+    def empty?(comment)
       comment.length == EMPTY
+    end
+
+    def only_newline?(comment)
+      empty?(comment.gsub(/\R/, ""))
     end
 end

--- a/app/views/theses/_comment.html.slim
+++ b/app/views/theses/_comment.html.slim
@@ -16,7 +16,7 @@
     = form_for [@thesis, @thesis.comments.build] do |f|
       .form-group
         .col-sm-11
-          = f.text_area :body, class: "form-control", placeholder: "コメント"
+          = f.text_area :body, class: "form-control", placeholder: "コメント(10行以下, 20文字以上, 400文字以下)"
       .form-group
         .col-sm-11
           = f.submit class: "btn btn-primary btn-block"


### PR DESCRIPTION
## Theses comment validation
### 仕様
空コメントまたは改行のみのコメントは無効
複数の改行があった場合、一つの改行にまとめる
改行のトリミングをしたコメントにおいて 10 行まで有効。11 行目以上のコメントは無効
 
 ### 改善点
`theses/show` に render で badrequest 返すべき

related[#164](https://github.com/yaaaaashiki/Escapism/issues/164)