### PR TITLE
Feature/labo password session

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,11 +21,20 @@ class UsersController < ApplicationController
       render_404
       return
     end
+    @labos = Labo.all
   end
 
   def create
     @user = User.new(user_params)
     @user.role = @user.get_role
+    if strong_params[:password].present? || strong_params[:labo].present?
+      labo = Labo.all.find(labo_password_params[:id])
+      if !labo.authoricate(labo_password_params[:password])
+        render :new, status: :bad_request
+      end
+    else
+      render :new, status: :bad_request
+    end
     @user.save!  # && MailAddress.find_by(address: params[:user][:email])
     log_in @user
     session[:user_create] = true
@@ -36,8 +45,26 @@ class UsersController < ApplicationController
   end
 
   private
+    def strong_params
+      params.require(:user).permit(:username, :year, :email, :password, :labo, :labo_password)
+    end
+
     def user_params
-      params.require(:user).permit(:username, :year, :email, :password)
+      params = strong_params
+      {
+        username: params[:username],
+        year: params[:year],
+        email: params[:email],
+        password: params[:password]
+      }
+    end
+
+    def labo_password_params
+      params = strong_params
+      {
+        id: params[:labo],
+        password: params[:labo_password]
+      }
     end
 
     def init_user_create_session

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,6 @@ class UsersController < ApplicationController
       render_404
       return
     end
-    @labos = Labo.all
   end
 
   def create
@@ -31,9 +30,11 @@ class UsersController < ApplicationController
       labo = Labo.all.find(labo_password_params[:id])
       if !labo.authoricate(labo_password_params[:password])
         render :new, status: :bad_request
+        return
       end
     else
       render :new, status: :bad_request
+      return
     end
     @user.save!  # && MailAddress.find_by(address: params[:user][:email])
     log_in @user

--- a/app/models/labo.rb
+++ b/app/models/labo.rb
@@ -65,7 +65,7 @@ class Labo < ApplicationRecord
     end
   end
 
-  def authoricate(name, password)
+  def authoricate(password)
     return false if Labo.crypt_password(password, self.salt) != self.crypted_password
     true
   end

--- a/app/views/admin/layouts/_admin_lte_2_sidebar.html.slim
+++ b/app/views/admin/layouts/_admin_lte_2_sidebar.html.slim
@@ -48,3 +48,8 @@ aside.main-sidebar
           i.fa.fa-link
           span
             | update user password
+      li.active
+        a[href="/admin/labos"]
+          i.fa.fa-link
+          span
+            | update lab password

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -15,6 +15,6 @@
       = f.password_field :password, class: "text-field", placeholder: "password", :size => "60"
       br
 
-      = f.collection_select :labo, @labos, :id, :name
+      = f.collection_select :labo, Labo.all, :id, :name
       = f.password_field :labo_password, class: "text-field", placeholder: "lab's password", :size => "60"
       = f.submit class: "button"

--- a/app/views/users/_form.html.slim
+++ b/app/views/users/_form.html.slim
@@ -14,4 +14,7 @@
       br
       = f.password_field :password, class: "text-field", placeholder: "password", :size => "60"
       br
+
+      = f.collection_select :labo, @labos, :id, :name
+      = f.password_field :labo_password, class: "text-field", placeholder: "lab's password", :size => "60"
       = f.submit class: "button"


### PR DESCRIPTION
## 概要
研究生に関する研究室パスワードの認証機能の実装

## 仕様
### 前提
セレクトボックス、パスワードボックスのどちらかに値が入力されているとき、研究生
どちらも入力されていないとき、学生とみなす

### 認証のタイミング
***学生*** のユーザ登録時、研究室パスワードの認証処理は走らない (***研究生のみ***)

### 成功時
入力を受けたパスワードが、研究室パスワードと一致したとき、
ユーザ登録処理が走り、登録成功画面にリダイレクト

### 失敗時
入力したパスワードが研究室パスワードと異なる時、失敗時には 再render `400 badrequest` を返す
セレクトボックスとパスワードボックスのどちらか一方にしか入力されていないとき、 再render `400 badrequest` を返す

related[#190](https://github.com/yaaaaashiki/Escapism/issues/190)